### PR TITLE
Fix syntax errors causing installation failures

### DIFF
--- a/module/customize.sh
+++ b/module/customize.sh
@@ -1541,7 +1541,7 @@ if [ -d /data/data/com.google.android.googlequicksearchbox ] && [ $API -ge 29 ] 
         echo " - Installing Google Journal" >>$logfile
         print "- Installing Google Journal"
         print ""
-        . $MODPATH/installAPK.sh Journal.apk
+        . $MODPATH/installAPK.sh Journal.apk $MODPATH/files/Journal.apk
      fi
 fi
 
@@ -2286,7 +2286,7 @@ $REMOVE
 " >>$logfile
 
 echo " ---- Installation Finished ----" >>$logfile
-fi
+
 print ""
 print "- Done"
 print ""

--- a/module/installAPK.sh
+++ b/module/installAPK.sh
@@ -30,7 +30,7 @@ elif [ $APK_CUT == apks ] || [ $APK_CUT == apkm ]; then
    APK_SIZE=$( $APKSIZE + $SIZE )
  done
 
- SESSION=$(pm install-create -S $SIZE | grep -Eo '[0-9]'+]
+ SESSION=$(pm install-create -S $SIZE | grep -Eo '[0-9]'+])
  echo "Session created with ID $SESSION and size $SIZE"
 
  I=0

--- a/module/installAPK.sh
+++ b/module/installAPK.sh
@@ -30,7 +30,7 @@ elif [ $APK_CUT == apks ] || [ $APK_CUT == apkm ]; then
    APK_SIZE=$( $APKSIZE + $SIZE )
  done
 
- SESSION=$(pm install-create -S $SIZE | grep -Eo '[0-9]'+])
+ SESSION=$(pm install-create -S $SIZE | grep -Eo '[0-9]+')
  echo "Session created with ID $SESSION and size $SIZE"
 
  I=0


### PR DESCRIPTION
Fix syntax errors in "customize.sh" and "installAPK.sh" leading to installation failures on some devices.
This should resolve issue #25.